### PR TITLE
Remove variance declarations and add note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Libraries useful for Dafny programs
 
+*This is a fork of `dafny-lang/libraries`* with variance declarations on type parameters removed,
+and hence supports compilation to Java despite https://github.com/dafny-lang/dafny/issues/2013.
+
 ## Status
 
 At the moment, we're just collecting generally useful Dafny code.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Libraries useful for Dafny programs
 
-*This is a fork of `dafny-lang/libraries`* with variance declarations on type parameters removed,
-and hence supports compilation to Java despite https://github.com/dafny-lang/dafny/issues/2013.
+**This is a fork of [`dafny-lang/libraries`](https://github.com/dafny-lang/libraries)** with variance declarations on type parameters removed,
+and which therefore supports compilation to Java despite https://github.com/dafny-lang/dafny/issues/2013.
 
 ## Status
 

--- a/src/Unicode/Utf16EncodingForm.dfy
+++ b/src/Unicode/Utf16EncodingForm.dfy
@@ -58,8 +58,10 @@ module Utf16EncodingForm refines UnicodeEncodingForm {
       && prefix == s[..|prefix|]
       && IsMinimalWellFormedCodeUnitSubsequence(prefix)
   {
-    if |s| >= 1 && IsWellFormedSingleCodeUnitSequence(s[..1]) then Some(s[..1])
-    else if |s| >= 2 && IsWellFormedDoubleCodeUnitSequence(s[..2]) then Some(s[..2])
+    if |s| >= 1 && IsWellFormedSingleCodeUnitSequence(s[..1]) then
+      var r: MinimalWellFormedCodeUnitSeq := s[..1]; Some(r)
+    else if |s| >= 2 && IsWellFormedDoubleCodeUnitSequence(s[..2]) then
+      var r: MinimalWellFormedCodeUnitSeq := s[..2]; Some(r)
     else None
   }
 

--- a/src/Unicode/Utf16EncodingForm.dfy
+++ b/src/Unicode/Utf16EncodingForm.dfy
@@ -58,6 +58,9 @@ module Utf16EncodingForm refines UnicodeEncodingForm {
       && prefix == s[..|prefix|]
       && IsMinimalWellFormedCodeUnitSubsequence(prefix)
   {
+    // Attaching the subset types explicitly to work around
+    // type inference not picking them (unless Option<T> is declared as Option<+T>).
+    // BUG(https://github.com/dafny-lang/dafny/issues/2551)
     if |s| >= 1 && IsWellFormedSingleCodeUnitSequence(s[..1]) then
       var r: MinimalWellFormedCodeUnitSeq := s[..1]; Some(r)
     else if |s| >= 2 && IsWellFormedDoubleCodeUnitSequence(s[..2]) then

--- a/src/Unicode/Utf8EncodingForm.dfy
+++ b/src/Unicode/Utf8EncodingForm.dfy
@@ -106,6 +106,9 @@ module Utf8EncodingForm refines UnicodeEncodingForm {
   function method SplitPrefixMinimalWellFormedCodeUnitSubsequence(s: CodeUnitSeq):
     (maybePrefix: Option<MinimalWellFormedCodeUnitSeq>)
   {
+    // Attaching the subset types explicitly to work around
+    // type inference not picking it (unless Option<T> is declared as Option<+T>).
+    // BUG(https://github.com/dafny-lang/dafny/issues/2551)
     if |s| >= 1 && IsWellFormedSingleCodeUnitSequence(s[..1]) then 
       var r: MinimalWellFormedCodeUnitSeq := s[..1]; Some(r)
     else if |s| >= 2 && IsWellFormedDoubleCodeUnitSequence(s[..2]) then

--- a/src/Unicode/Utf8EncodingForm.dfy
+++ b/src/Unicode/Utf8EncodingForm.dfy
@@ -106,10 +106,14 @@ module Utf8EncodingForm refines UnicodeEncodingForm {
   function method SplitPrefixMinimalWellFormedCodeUnitSubsequence(s: CodeUnitSeq):
     (maybePrefix: Option<MinimalWellFormedCodeUnitSeq>)
   {
-    if |s| >= 1 && IsWellFormedSingleCodeUnitSequence(s[..1]) then Some(s[..1])
-    else if |s| >= 2 && IsWellFormedDoubleCodeUnitSequence(s[..2]) then Some(s[..2])
-    else if |s| >= 3 && IsWellFormedTripleCodeUnitSequence(s[..3]) then Some(s[..3])
-    else if |s| >= 4 && IsWellFormedQuadrupleCodeUnitSequence(s[..4]) then Some(s[..4])
+    if |s| >= 1 && IsWellFormedSingleCodeUnitSequence(s[..1]) then 
+      var r: MinimalWellFormedCodeUnitSeq := s[..1]; Some(r)
+    else if |s| >= 2 && IsWellFormedDoubleCodeUnitSequence(s[..2]) then
+      var r: MinimalWellFormedCodeUnitSeq := s[..2]; Some(r)
+    else if |s| >= 3 && IsWellFormedTripleCodeUnitSequence(s[..3]) then
+      var r: MinimalWellFormedCodeUnitSeq := s[..3]; Some(r)
+    else if |s| >= 4 && IsWellFormedQuadrupleCodeUnitSequence(s[..4]) then
+      var r: MinimalWellFormedCodeUnitSeq := s[..4]; Some(r)
     else None
   }
 

--- a/src/Wrappers.dfy
+++ b/src/Wrappers.dfy
@@ -35,6 +35,13 @@ module Wrappers {
     {
       value
     }
+
+    function method Map<NewT>(reWrap: T -> NewT): Option<NewT>
+    {
+      match this
+      case Some(v) => Success(reWrap(v))
+      case None => None
+    }
   }
 
   datatype Result<T, R> = | Success(value: T) | Failure(error: R) {
@@ -60,6 +67,13 @@ module Wrappers {
       requires Failure?
     {
       Failure(this.error)
+    }
+
+    function method MapSuccess<NewT>(reWrap: T -> NewT): Result<NewT, E>
+    {
+      match this
+      case Success(s) => Success(reWrap(s))
+      case Failure(e) => Failure(e)
     }
 
     function method MapFailure<NewR>(reWrap: R -> NewR): Result<T, NewR>

--- a/src/Wrappers.dfy
+++ b/src/Wrappers.dfy
@@ -39,7 +39,7 @@ module Wrappers {
     function method Map<NewT>(reWrap: T -> NewT): Option<NewT>
     {
       match this
-      case Some(v) => Success(reWrap(v))
+      case Some(v) => Some(reWrap(v))
       case None => None
     }
   }
@@ -69,7 +69,7 @@ module Wrappers {
       Failure(this.error)
     }
 
-    function method MapSuccess<NewT>(reWrap: T -> NewT): Result<NewT, E>
+    function method MapSuccess<NewT>(reWrap: T -> NewT): Result<NewT, R>
     {
       match this
       case Success(s) => Success(reWrap(s))

--- a/src/Wrappers.dfy
+++ b/src/Wrappers.dfy
@@ -7,7 +7,7 @@
 
 module Wrappers {
   
-  datatype Option<+T> = None | Some(value: T) {
+  datatype Option<T> = None | Some(value: T) {
     function method ToResult(): Result<T, string> {
       match this
       case Some(v) => Success(v)
@@ -37,7 +37,7 @@ module Wrappers {
     }
   }
 
-  datatype Result<+T, +R> = | Success(value: T) | Failure(error: R) {
+  datatype Result<T, R> = | Success(value: T) | Failure(error: R) {
     function method ToOption(): Option<T> 
     {
       match this


### PR DESCRIPTION
The small changes here (satisfying the type checker and adding methods useful for "upcasting" non-variant wrappers) will be ported back to `dafny-lang/libraries` immediately after merging this.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
